### PR TITLE
sdk/elf2sgxs: reject --nssa > 1 until exception support lands

### DIFF
--- a/sdk/tools/elf2sgxs.c
+++ b/sdk/tools/elf2sgxs.c
@@ -133,7 +133,7 @@ static int parse_args(int argc, char *argv[])
         } else if (!strcmp(argv[i], "--nssa")) {
             BARESGX_ASSERT_RET((i+1) < argc, "nssa");
             g_nssa = atoi(argv[++i]);
-            BARESGX_ASSERT_RET(g_nssa > 0, "nssa");
+            BARESGX_ASSERT_RET(g_nssa == 1, "nssa (exceptions not supported)");
         } else if (!strcmp(argv[i], "--entry")) {
             BARESGX_ASSERT_RET((i+1) < argc, "entry");
             g_entry_symbol = argv[++i];


### PR DESCRIPTION
bare-sgx does not currently support enclave exception handling (see README roadmap), but elf2sgxs accepts an --nssa flag that would let out-of-tree apps build enclaves with NSSA > 1, which the runtime is not designed for. Restrict --nssa to == 1 with a clearer error message; the default behaviour (flag not passed, g_nssa stays 1) is unchanged.

PR arising from email discussion with @Hayao0819 