### PR TITLE
sdk/trts: add opt-in STACK_CLEANSING for defense in depth

### DIFF
--- a/sdk/trts/Makefile
+++ b/sdk/trts/Makefile
@@ -22,7 +22,7 @@ $(OUTPUT): $(OBJECTS)
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(INCLUDE) -c $< -o $@
 
 %.o : %.S
-	$(AS) $(ASFLAGS) $(INCLUDE) -c $< -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(INCLUDE) -c $< -o $@
 
 clean:
 	rm -f $(OBJECTS) $(OUTPUT)

--- a/sdk/trts/entry.S
+++ b/sdk/trts/entry.S
@@ -48,6 +48,16 @@ encl_entry:
 	xor     %r15, %r15
 	add     %rax, %rax # OF = SF = AF = CF = 0; ZF = PF = 1
 
+#ifdef STACK_CLEANSING
+	# Opt-in defense-in-depth: wipe .stack except the top 16 bytes
+	lea     encl_stack(%rip), %rdi
+	sub     $4096, %rdi
+	mov     $510, %rcx
+	rep stosq
+	xor     %rdi, %rdi
+	xor     %rcx, %rcx
+#endif
+
 	# Restore eexit_target and ursp
 	pop	    %rbx
 	pop	    %rsp


### PR DESCRIPTION
bare-trts already wipes all GP registers and sanitises RFLAGS before EEXIT to prevent cross-ECALL register leakage. The .stack page itself is not zeroed between entries, which is correct for standard-compliant C code (reading an uninitialised stack local is UB) but leaves no safety net should an enclave inadvertently introduce such UB.

Add an opt-in hardening pass that `rep stosq`s the bottom 4080 bytes of .stack just before EEXIT, leaving the top 16 bytes (saved u_rsp / eexit_target) intact for the two pops below. Enabled with -DSTACK_CLEANSING; default off so existing enclaves see no cycle-count change.

Switch the .S build rule in sdk/trts/Makefile from $(AS) to $(CC) so the C preprocessor runs on entry.S — required for the #ifdef to take effect.

PR arising from email discussion with @Hayao0819